### PR TITLE
Fix missing error messages for checkbox item validation

### DIFF
--- a/src/FormField.php
+++ b/src/FormField.php
@@ -302,7 +302,7 @@ class FormField
     public function checkboxes($name, array $checkboxOptions, $options = [])
     {
         $requiredClass = (isset($options['required']) && $options['required'] == true) ? 'required ' : '';
-        $hasError = !!$this->getErrorMessage($name, $checkboxOptions);
+        $hasError = (bool) $this->getErrorMessage($name, $checkboxOptions);
         $hasErrorClass = $hasError ? 'has-error' : '';
 
         $htmlForm = '<div class="form-group '.$requiredClass.$hasErrorClass.'">';

--- a/src/FormField.php
+++ b/src/FormField.php
@@ -302,7 +302,7 @@ class FormField
     public function checkboxes($name, array $checkboxOptions, $options = [])
     {
         $requiredClass = (isset($options['required']) && $options['required'] == true) ? 'required ' : '';
-        $hasError = $this->errorBag->has($name);
+        $hasError = !!$this->getErrorMessage($name, $checkboxOptions);
         $hasErrorClass = $hasError ? 'has-error' : '';
 
         $htmlForm = '<div class="form-group '.$requiredClass.$hasErrorClass.'">';
@@ -337,10 +337,22 @@ class FormField
 
         $htmlForm .= $this->getInfoTextLine($options);
 
-        $htmlForm .= $this->errorBag->first($this->formatArrayName($name), '<span class="small text-danger" role="alert">:message</span>');
+        $htmlForm .= $this->getErrorMessage($name, $checkboxOptions);
         $htmlForm .= '</div>';
 
         return $htmlForm;
+    }
+
+    private function getErrorMessage($name, $checkboxOptions = [])
+    {
+        $message = '';
+        $message .= $this->errorBag->first($this->formatArrayName($name)).' ';
+        foreach (array_keys($checkboxOptions) as $index => $key) {
+            $message .= $this->errorBag->first($name.'.'.$index).' ';
+        }
+        $message = trim($message);
+
+        return $message ? '<span class="small text-danger" role="alert">'.$message.'</span>' : null;
     }
 
     /**

--- a/tests/Fields/CheckBoxesTest.php
+++ b/tests/Fields/CheckBoxesTest.php
@@ -111,4 +111,28 @@ class CheckBoxesTest extends TestCase
             $this->formField->checkboxes('checkboxes', [1 => 'Satu', 2 => 'Dua'])
         );
     }
+
+    /** @test */
+    public function it_shows_checkboxes_validation_error_for_each_index()
+    {
+        // Mock error message on "checkboxes" attribute.
+        $errorBag = new \Illuminate\Support\MessageBag();
+        $errorBag->add('checkboxes.0', 'The selected checkboxes.0 is invalid.');
+        $errorBag->add('checkboxes.0', 'The selected checkboxes.0 must be a string.');
+        $errorBag->add('checkboxes.1', 'The selected checkboxes.1 must be a string.');
+
+        $this->formField->errorBag = $errorBag;
+
+        $generatedString = '<div class="form-group has-error">';
+        $generatedString .= '<label for="checkboxes" class="form-label">Checkboxes</label>&nbsp;<div>';
+        $generatedString .= '<div class="form-check form-check-inline"><input id="checkboxes_one" class="form-check-input is-invalid" name="checkboxes[]" type="checkbox" value="one"><label for="checkboxes_one" class="form-check-label">Satu</label></div>';
+        $generatedString .= '<div class="form-check form-check-inline"><input id="checkboxes_two" class="form-check-input is-invalid" name="checkboxes[]" type="checkbox" value="two"><label for="checkboxes_two" class="form-check-label">Dua</label></div></div>';
+        $generatedString .= '<span class="small text-danger" role="alert">The selected checkboxes.0 is invalid. The selected checkboxes.1 must be a string.</span>';
+        $generatedString .= '</div>';
+
+        $this->assertEquals(
+            $generatedString,
+            $this->formField->checkboxes('checkboxes', ['one' => 'Satu', 'two' => 'Dua'])
+        );
+    }
 }


### PR DESCRIPTION
In this PR, we are fixing the missing error messages on checkbox validation fails, which only happen when we set validation rules for each checkbox items.

![screen_20-05-21_010](https://user-images.githubusercontent.com/8721551/82568470-7143b200-9bb1-11ea-8880-61725aa859c4.jpg)

## How to Test

```
$ composer require luthfi/formfield dev-bugfix_missing_checkbox_validation_messages
```
We should get commit 7806be3.

This should resolves #7.