### PR TITLE
Add FormField::fileDrop

### DIFF
--- a/src/FormField.php
+++ b/src/FormField.php
@@ -418,10 +418,10 @@ class FormField
         $multiple = isset($options['multiple']) && $options['multiple'] ? 'multiple' : '';
         $maxSize = isset($options['max_size']) ? $options['max_size'] : '10MB';
         $allowedTypes = isset($options['allowed_types']) ? implode(', ', $options['allowed_types']) : 'All files';
-        
+
         // Sanitize field ID for use in HTML IDs (remove square brackets and other invalid characters)
         $sanitizedFieldId = preg_replace('/[^a-zA-Z0-9_-]/', '', $fieldId);
-        
+
         $dropzoneId = 'dropzone-'.$sanitizedFieldId;
         $fileInputId = 'file-input-'.$sanitizedFieldId;
         $previewId = 'preview-'.$sanitizedFieldId;

--- a/src/FormField.php
+++ b/src/FormField.php
@@ -398,13 +398,13 @@ class FormField
     }
 
     /**
-     * Modern file input field with drag-and-drop and clipboard paste functionality.
+     * Drop file input field with drag-and-drop and clipboard paste functionality.
      *
      * @param  string  $name  The file field name and id attribute.
      * @param  array  $options  Additional attribute for the file input.
-     * @return string Generated modern file input form field.
+     * @return string Generated drop file input form field.
      */
-    public function fileModern($name, $options = [])
+    public function fileDrop($name, $options = [])
     {
         $requiredClass = (isset($options['required']) && $options['required'] == true) ? 'required ' : '';
         $hasError = $this->errorBag->has($this->formatArrayName($name));
@@ -422,13 +422,13 @@ class FormField
         // Sanitize field ID for use in HTML IDs (remove square brackets and other invalid characters)
         $sanitizedFieldId = preg_replace('/[^a-zA-Z0-9_-]/', '', $fieldId);
         
-        $dropzoneId = 'dropzone-' . $sanitizedFieldId;
-        $fileInputId = 'file-input-' . $sanitizedFieldId;
-        $previewId = 'preview-' . $sanitizedFieldId;
+        $dropzoneId = 'dropzone-'.$sanitizedFieldId;
+        $fileInputId = 'file-input-'.$sanitizedFieldId;
+        $previewId = 'preview-'.$sanitizedFieldId;
 
         // Container with dropzone styling
         $htmlForm .= '<div id="'.$dropzoneId.'" class="file-dropzone border border-2 border-dashed rounded p-4 text-center position-relative" style="min-height: 150px; cursor: pointer; transition: all 0.3s ease;">';
-        
+
         // Hidden file input
         $htmlForm .= '<input type="file" id="'.$fileInputId.'" name="'.$name.'" class="d-none" accept="'.$accept.'" '.$multiple;
         if (isset($options['required']) && $options['required'] == true) {
@@ -455,7 +455,7 @@ class FormField
         $htmlForm .= '</div>';
 
         // Add the JavaScript for drag-and-drop and clipboard functionality
-        $htmlForm .= $this->getFileModernScript($dropzoneId, $fileInputId, $previewId, $accept, $multiple);
+        $htmlForm .= $this->getFileDropScript($dropzoneId, $fileInputId, $previewId, $accept, $multiple);
 
         $htmlForm .= $this->getInfoTextLine($options);
 
@@ -467,7 +467,7 @@ class FormField
     }
 
     /**
-     * Generate JavaScript for modern file input functionality.
+     * Generate JavaScript for drop file input functionality.
      *
      * @param  string  $dropzoneId  The dropzone element ID.
      * @param  string  $fileInputId  The file input element ID.
@@ -476,7 +476,7 @@ class FormField
      * @param  string  $multiple  Multiple files flag.
      * @return string JavaScript code.
      */
-    private function getFileModernScript($dropzoneId, $fileInputId, $previewId, $accept, $multiple)
+    private function getFileDropScript($dropzoneId, $fileInputId, $previewId, $accept, $multiple)
     {
         $script = '<script>';
         $script .= '(function() {';
@@ -484,7 +484,7 @@ class FormField
         $script .= 'const fileInput = document.getElementById("'.$fileInputId.'");';
         $script .= 'const preview = document.getElementById("'.$previewId.'");';
         $script .= 'let selectedFiles = [];';
-        
+
         // Click handler
         $script .= 'dropzone.addEventListener("click", function(e) {';
         $script .= 'if (e.target === dropzone || e.target.closest(".dropzone-content")) {';
@@ -524,33 +524,33 @@ class FormField
         // Clipboard paste handler
         $script .= 'let lastDropzoneInteraction = null;';
         $script .= 'let dropzoneInteractionTimeout = null;';
-        
+
         // Track interactions with the dropzone
         $script .= 'dropzone.addEventListener("click", function() {';
         $script .= 'lastDropzoneInteraction = Date.now();';
         $script .= 'clearTimeout(dropzoneInteractionTimeout);';
         $script .= 'dropzoneInteractionTimeout = setTimeout(() => { lastDropzoneInteraction = null; }, 10000);';
         $script .= '});';
-        
+
         $script .= 'dropzone.addEventListener("focus", function() {';
         $script .= 'lastDropzoneInteraction = Date.now();';
         $script .= 'clearTimeout(dropzoneInteractionTimeout);';
         $script .= 'dropzoneInteractionTimeout = setTimeout(() => { lastDropzoneInteraction = null; }, 10000);';
         $script .= '}, true);';
-        
+
         $script .= 'document.addEventListener("paste", function(e) {';
         $script .= 'let shouldHandle = false;';
-        
+
         // Check if activeElement is inside dropzone
         $script .= 'if (document.activeElement && (dropzone.contains(document.activeElement) || document.activeElement.closest("#'.$dropzoneId.'"))) {';
         $script .= 'shouldHandle = true;';
         $script .= '}';
-        
+
         // Check if dropzone was recently interacted with
         $script .= 'if (!shouldHandle && lastDropzoneInteraction && (Date.now() - lastDropzoneInteraction < 5000)) {';
         $script .= 'shouldHandle = true;';
         $script .= '}';
-        
+
         // Check if dropzone is visible and cursor is over it
         $script .= 'if (!shouldHandle) {';
         $script .= 'const rect = dropzone.getBoundingClientRect();';
@@ -561,7 +561,7 @@ class FormField
         $script .= 'shouldHandle = true;';
         $script .= '}';
         $script .= '}';
-        
+
         $script .= 'if (shouldHandle) {';
         $script .= 'const items = e.clipboardData.items;';
         $script .= 'const files = [];';
@@ -607,12 +607,12 @@ class FormField
         $script .= 'rejectedFiles.push(file);';
         $script .= '}';
         $script .= '}';
-        
+
         $script .= 'if (rejectedFiles.length > 0) {';
         $script .= 'const rejectedNames = rejectedFiles.map(f => f.name).join(", ");';
         $script .= 'alert("The following files are not accepted based on the file type restrictions: " + rejectedNames);';
         $script .= '}';
-        
+
         $script .= 'if (acceptedFiles.length > 0) {';
         $script .= 'if ("'.$multiple.'" === "multiple") {';
         $script .= 'selectedFiles = selectedFiles.concat(acceptedFiles);';
@@ -642,19 +642,19 @@ class FormField
         $script .= 'preview.style.display = "block";';
         $script .= 'const fileList = document.createElement("div");';
         $script .= 'fileList.className = "list-group";';
-        
+
         $script .= 'for (let i = 0; i < selectedFiles.length; i++) {';
         $script .= 'const file = selectedFiles[i];';
         $script .= 'const fileItem = document.createElement("div");';
         $script .= 'fileItem.className = "list-group-item d-flex justify-content-between align-items-center";';
         $script .= 'fileItem.setAttribute("data-file-index", i);';
-        
+
         $script .= 'const fileInfo = document.createElement("div");';
         $script .= 'fileInfo.innerHTML = "<strong>" + file.name + "</strong><br><small class=\"text-muted\">" + formatFileSize(file.size) + "</small>";';
-        
+
         $script .= 'const fileActions = document.createElement("div");';
         $script .= 'fileActions.className = "d-flex align-items-center gap-2";';
-        
+
         $script .= 'const fileIcon = document.createElement("span");';
         $script .= 'if (file.type.startsWith("image/")) {';
         $script .= 'fileIcon.innerHTML = "🖼️";';
@@ -663,7 +663,7 @@ class FormField
         $script .= '} else {';
         $script .= 'fileIcon.innerHTML = "📎";';
         $script .= '}';
-        
+
         $script .= 'const deleteBtn = document.createElement("button");';
         $script .= 'deleteBtn.type = "button";';
         $script .= 'deleteBtn.className = "btn btn-sm btn-outline-danger";';
@@ -674,15 +674,15 @@ class FormField
         $script .= 'e.preventDefault();';
         $script .= 'removeFile(parseInt(this.getAttribute("data-file-index")));';
         $script .= '});';
-        
+
         $script .= 'fileActions.appendChild(fileIcon);';
         $script .= 'fileActions.appendChild(deleteBtn);';
-        
+
         $script .= 'fileItem.appendChild(fileInfo);';
         $script .= 'fileItem.appendChild(fileActions);';
         $script .= 'fileList.appendChild(fileItem);';
         $script .= '}';
-        
+
         $script .= 'preview.appendChild(fileList);';
         $script .= '} else {';
         $script .= 'preview.style.display = "none";';

--- a/tests/Fields/FileDropTest.php
+++ b/tests/Fields/FileDropTest.php
@@ -53,7 +53,7 @@ class FileDropTest extends TestCase
             'id' => 'custom_id',
             'max_size' => '5MB',
             'allowed_types' => ['JPG', 'PNG', 'PDF'],
-            'label' => 'Custom File Upload'
+            'label' => 'Custom File Upload',
         ]);
 
         $this->assertTrue(str_contains($result, 'id="file-input-custom_id"'));
@@ -66,7 +66,7 @@ class FileDropTest extends TestCase
     public function it_returns_drop_file_upload_field_with_info_text()
     {
         $result = $this->formField->fileDrop('info_file', [
-            'info' => ['text' => 'This is help text', 'class' => 'warning']
+            'info' => ['text' => 'This is help text', 'class' => 'warning'],
         ]);
 
         $this->assertTrue(str_contains($result, 'This is help text'));
@@ -139,13 +139,13 @@ class FileDropTest extends TestCase
 
         $this->assertTrue(str_contains($result, 'lastDropzoneInteraction'));
         $this->assertTrue(str_contains($result, 'dropzoneInteractionTimeout'));
-        
+
         $this->assertTrue(str_contains($result, 'shouldHandle = false'));
         $this->assertTrue(str_contains($result, 'dropzone.contains(document.activeElement)'));
         $this->assertTrue(str_contains($result, 'Date.now() - lastDropzoneInteraction'));
         $this->assertTrue(str_contains($result, 'getBoundingClientRect()'));
         $this->assertTrue(str_contains($result, 'elementFromPoint'));
-        
+
         $this->assertTrue(str_contains($result, 'dropzone.addEventListener("click"'));
         $this->assertTrue(str_contains($result, 'dropzone.addEventListener("focus"'));
     }
@@ -160,12 +160,12 @@ class FileDropTest extends TestCase
         $this->assertTrue(str_contains($result, 'acceptString.split'));
         $this->assertTrue(str_contains($result, 'file.name.toLowerCase().endsWith'));
         $this->assertTrue(str_contains($result, 'file.type.startsWith'));
-        
+
         // Should validate files in addFiles function
         $this->assertTrue(str_contains($result, 'const acceptedFiles = []'));
         $this->assertTrue(str_contains($result, 'const rejectedFiles = []'));
         $this->assertTrue(str_contains($result, 'isFileAccepted(file, "image/*")'));
-        
+
         // Should show rejection message
         $this->assertTrue(str_contains($result, 'files are not accepted based on the file type restrictions'));
     }

--- a/tests/Fields/FileDropTest.php
+++ b/tests/Fields/FileDropTest.php
@@ -5,12 +5,12 @@ namespace Tests\Fields;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-class FileModernTest extends TestCase
+class FileDropTest extends TestCase
 {
     #[Test]
-    public function it_returns_modern_file_upload_field()
+    public function it_returns_drop_file_upload_field()
     {
-        $result = $this->formField->fileModern('document');
+        $result = $this->formField->fileDrop('document');
 
         $this->assertTrue(str_contains($result, 'file-dropzone'));
         $this->assertTrue(str_contains($result, 'Drop files here or click to browse'));
@@ -22,34 +22,34 @@ class FileModernTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_modern_file_upload_field_with_accept_option()
+    public function it_returns_drop_file_upload_field_with_accept_option()
     {
-        $result = $this->formField->fileModern('images', ['accept' => 'image/*']);
+        $result = $this->formField->fileDrop('images', ['accept' => 'image/*']);
 
         $this->assertTrue(str_contains($result, 'accept="image/*"'));
     }
 
     #[Test]
-    public function it_returns_modern_file_upload_field_with_multiple_option()
+    public function it_returns_drop_file_upload_field_with_multiple_option()
     {
-        $result = $this->formField->fileModern('files', ['multiple' => true]);
+        $result = $this->formField->fileDrop('files', ['multiple' => true]);
 
         $this->assertTrue(str_contains($result, 'multiple'));
     }
 
     #[Test]
-    public function it_returns_modern_file_upload_field_with_required_attribute()
+    public function it_returns_drop_file_upload_field_with_required_attribute()
     {
-        $generatedString = $this->formField->fileModern('required_file', ['required' => true]);
+        $generatedString = $this->formField->fileDrop('required_file', ['required' => true]);
 
         $this->assertTrue(str_contains($generatedString, 'required '));
         $this->assertTrue(str_contains($generatedString, ' required'));
     }
 
     #[Test]
-    public function it_returns_modern_file_upload_field_with_custom_options()
+    public function it_returns_drop_file_upload_field_with_custom_options()
     {
-        $result = $this->formField->fileModern('custom_file', [
+        $result = $this->formField->fileDrop('custom_file', [
             'id' => 'custom_id',
             'max_size' => '5MB',
             'allowed_types' => ['JPG', 'PNG', 'PDF'],
@@ -63,9 +63,9 @@ class FileModernTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_modern_file_upload_field_with_info_text()
+    public function it_returns_drop_file_upload_field_with_info_text()
     {
-        $result = $this->formField->fileModern('info_file', [
+        $result = $this->formField->fileDrop('info_file', [
             'info' => ['text' => 'This is help text', 'class' => 'warning']
         ]);
 
@@ -76,8 +76,8 @@ class FileModernTest extends TestCase
     #[Test]
     public function it_generates_unique_ids_for_multiple_instances()
     {
-        $result1 = $this->formField->fileModern('file1');
-        $result2 = $this->formField->fileModern('file2');
+        $result1 = $this->formField->fileDrop('file1');
+        $result2 = $this->formField->fileDrop('file2');
 
         $this->assertTrue(str_contains($result1, 'dropzone-file1'));
         $this->assertTrue(str_contains($result2, 'dropzone-file2'));
@@ -88,7 +88,7 @@ class FileModernTest extends TestCase
     #[Test]
     public function it_includes_javascript_for_drag_and_drop_functionality()
     {
-        $result = $this->formField->fileModern('js_test');
+        $result = $this->formField->fileDrop('js_test');
 
         $this->assertTrue(str_contains($result, 'addEventListener("dragover"'));
         $this->assertTrue(str_contains($result, 'addEventListener("drop"'));
@@ -101,7 +101,7 @@ class FileModernTest extends TestCase
     #[Test]
     public function it_includes_accessibility_features()
     {
-        $result = $this->formField->fileModern('accessible_file');
+        $result = $this->formField->fileDrop('accessible_file');
 
         $this->assertTrue(str_contains($result, 'tabindex'));
         $this->assertTrue(str_contains($result, 'addEventListener("keydown"'));
@@ -112,7 +112,7 @@ class FileModernTest extends TestCase
     #[Test]
     public function it_includes_delete_file_functionality()
     {
-        $result = $this->formField->fileModern('deletable_files');
+        $result = $this->formField->fileDrop('deletable_files');
 
         $this->assertTrue(str_contains($result, 'removeFile'));
         $this->assertTrue(str_contains($result, 'btn-outline-danger'));
@@ -123,7 +123,7 @@ class FileModernTest extends TestCase
     #[Test]
     public function it_handles_array_field_names_correctly()
     {
-        $result = $this->formField->fileModern('files[]');
+        $result = $this->formField->fileDrop('files[]');
 
         $this->assertTrue(str_contains($result, 'id="dropzone-files"'));
         $this->assertTrue(str_contains($result, 'id="file-input-files"'));
@@ -135,7 +135,7 @@ class FileModernTest extends TestCase
     #[Test]
     public function it_includes_clipboard_paste_detection()
     {
-        $result = $this->formField->fileModern('paste_test');
+        $result = $this->formField->fileDrop('paste_test');
 
         $this->assertTrue(str_contains($result, 'lastDropzoneInteraction'));
         $this->assertTrue(str_contains($result, 'dropzoneInteractionTimeout'));
@@ -153,7 +153,7 @@ class FileModernTest extends TestCase
     #[Test]
     public function it_includes_file_validation_logic()
     {
-        $result = $this->formField->fileModern('images', ['accept' => 'image/*']);
+        $result = $this->formField->fileDrop('images', ['accept' => 'image/*']);
 
         // Should include file validation function
         $this->assertTrue(str_contains($result, 'function isFileAccepted'));
@@ -173,7 +173,7 @@ class FileModernTest extends TestCase
     #[Test]
     public function it_validates_clipboard_paste_files()
     {
-        $result = $this->formField->fileModern('docs', ['accept' => '.pdf,.doc']);
+        $result = $this->formField->fileDrop('docs', ['accept' => '.pdf,.doc']);
 
         // Should validate pasted files
         $this->assertTrue(str_contains($result, 'isFileAccepted(file, ".pdf,.doc")'));

--- a/tests/Fields/FileModernTest.php
+++ b/tests/Fields/FileModernTest.php
@@ -131,4 +131,22 @@ class FileModernTest extends TestCase
         $this->assertTrue(str_contains($result, 'name="files[]"'));
         $this->assertTrue(str_contains($result, 'getElementById("dropzone-files")'));
     }
+
+    #[Test]
+    public function it_includes_clipboard_paste_detection()
+    {
+        $result = $this->formField->fileModern('paste_test');
+
+        $this->assertTrue(str_contains($result, 'lastDropzoneInteraction'));
+        $this->assertTrue(str_contains($result, 'dropzoneInteractionTimeout'));
+        
+        $this->assertTrue(str_contains($result, 'shouldHandle = false'));
+        $this->assertTrue(str_contains($result, 'dropzone.contains(document.activeElement)'));
+        $this->assertTrue(str_contains($result, 'Date.now() - lastDropzoneInteraction'));
+        $this->assertTrue(str_contains($result, 'getBoundingClientRect()'));
+        $this->assertTrue(str_contains($result, 'elementFromPoint'));
+        
+        $this->assertTrue(str_contains($result, 'dropzone.addEventListener("click"'));
+        $this->assertTrue(str_contains($result, 'dropzone.addEventListener("focus"'));
+    }
 }

--- a/tests/Fields/FileModernTest.php
+++ b/tests/Fields/FileModernTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Fields;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class FileModernTest extends TestCase
+{
+    #[Test]
+    public function it_returns_modern_file_upload_field()
+    {
+        $result = $this->formField->fileModern('document');
+
+        $this->assertTrue(str_contains($result, 'file-dropzone'));
+        $this->assertTrue(str_contains($result, 'Drop files here or click to browse'));
+        $this->assertTrue(str_contains($result, 'Or paste images from clipboard'));
+        $this->assertTrue(str_contains($result, 'type="file"'));
+        $this->assertTrue(str_contains($result, 'name="document"'));
+        $this->assertTrue(str_contains($result, 'id="file-input-document"'));
+        $this->assertTrue(str_contains($result, '<script>'));
+    }
+
+    #[Test]
+    public function it_returns_modern_file_upload_field_with_accept_option()
+    {
+        $result = $this->formField->fileModern('images', ['accept' => 'image/*']);
+
+        $this->assertTrue(str_contains($result, 'accept="image/*"'));
+    }
+
+    #[Test]
+    public function it_returns_modern_file_upload_field_with_multiple_option()
+    {
+        $result = $this->formField->fileModern('files', ['multiple' => true]);
+
+        $this->assertTrue(str_contains($result, 'multiple'));
+    }
+
+    #[Test]
+    public function it_returns_modern_file_upload_field_with_required_attribute()
+    {
+        $generatedString = $this->formField->fileModern('required_file', ['required' => true]);
+
+        $this->assertTrue(str_contains($generatedString, 'required '));
+        $this->assertTrue(str_contains($generatedString, ' required'));
+    }
+
+    #[Test]
+    public function it_returns_modern_file_upload_field_with_custom_options()
+    {
+        $result = $this->formField->fileModern('custom_file', [
+            'id' => 'custom_id',
+            'max_size' => '5MB',
+            'allowed_types' => ['JPG', 'PNG', 'PDF'],
+            'label' => 'Custom File Upload'
+        ]);
+
+        $this->assertTrue(str_contains($result, 'id="file-input-custom_id"'));
+        $this->assertTrue(str_contains($result, 'Max size: 5MB'));
+        $this->assertTrue(str_contains($result, 'Accepted: JPG, PNG, PDF'));
+        $this->assertTrue(str_contains($result, 'Custom File Upload'));
+    }
+
+    #[Test]
+    public function it_returns_modern_file_upload_field_with_info_text()
+    {
+        $result = $this->formField->fileModern('info_file', [
+            'info' => ['text' => 'This is help text', 'class' => 'warning']
+        ]);
+
+        $this->assertTrue(str_contains($result, 'This is help text'));
+        $this->assertTrue(str_contains($result, 'text-warning'));
+    }
+
+    #[Test]
+    public function it_generates_unique_ids_for_multiple_instances()
+    {
+        $result1 = $this->formField->fileModern('file1');
+        $result2 = $this->formField->fileModern('file2');
+
+        $this->assertTrue(str_contains($result1, 'dropzone-file1'));
+        $this->assertTrue(str_contains($result2, 'dropzone-file2'));
+        $this->assertTrue(str_contains($result1, 'file-input-file1'));
+        $this->assertTrue(str_contains($result2, 'file-input-file2'));
+    }
+
+    #[Test]
+    public function it_includes_javascript_for_drag_and_drop_functionality()
+    {
+        $result = $this->formField->fileModern('js_test');
+
+        $this->assertTrue(str_contains($result, 'addEventListener("dragover"'));
+        $this->assertTrue(str_contains($result, 'addEventListener("drop"'));
+        $this->assertTrue(str_contains($result, 'addEventListener("paste"'));
+        $this->assertTrue(str_contains($result, 'addEventListener("click"'));
+        $this->assertTrue(str_contains($result, 'addFiles'));
+        $this->assertTrue(str_contains($result, 'formatFileSize'));
+    }
+
+    #[Test]
+    public function it_includes_accessibility_features()
+    {
+        $result = $this->formField->fileModern('accessible_file');
+
+        $this->assertTrue(str_contains($result, 'tabindex'));
+        $this->assertTrue(str_contains($result, 'addEventListener("keydown"'));
+        $this->assertTrue(str_contains($result, 'e.key === "Enter"'));
+        $this->assertTrue(str_contains($result, 'e.key === " "'));
+    }
+
+    #[Test]
+    public function it_includes_delete_file_functionality()
+    {
+        $result = $this->formField->fileModern('deletable_files');
+
+        $this->assertTrue(str_contains($result, 'removeFile'));
+        $this->assertTrue(str_contains($result, 'btn-outline-danger'));
+        $this->assertTrue(str_contains($result, 'Remove file'));
+        $this->assertTrue(str_contains($result, 'selectedFiles'));
+    }
+
+    #[Test]
+    public function it_handles_array_field_names_correctly()
+    {
+        $result = $this->formField->fileModern('files[]');
+
+        $this->assertTrue(str_contains($result, 'id="dropzone-files"'));
+        $this->assertTrue(str_contains($result, 'id="file-input-files"'));
+        $this->assertTrue(str_contains($result, 'id="preview-files"'));
+        $this->assertTrue(str_contains($result, 'name="files[]"'));
+        $this->assertTrue(str_contains($result, 'getElementById("dropzone-files")'));
+    }
+}

--- a/tests/Fields/FileModernTest.php
+++ b/tests/Fields/FileModernTest.php
@@ -149,4 +149,33 @@ class FileModernTest extends TestCase
         $this->assertTrue(str_contains($result, 'dropzone.addEventListener("click"'));
         $this->assertTrue(str_contains($result, 'dropzone.addEventListener("focus"'));
     }
+
+    #[Test]
+    public function it_includes_file_validation_logic()
+    {
+        $result = $this->formField->fileModern('images', ['accept' => 'image/*']);
+
+        // Should include file validation function
+        $this->assertTrue(str_contains($result, 'function isFileAccepted'));
+        $this->assertTrue(str_contains($result, 'acceptString.split'));
+        $this->assertTrue(str_contains($result, 'file.name.toLowerCase().endsWith'));
+        $this->assertTrue(str_contains($result, 'file.type.startsWith'));
+        
+        // Should validate files in addFiles function
+        $this->assertTrue(str_contains($result, 'const acceptedFiles = []'));
+        $this->assertTrue(str_contains($result, 'const rejectedFiles = []'));
+        $this->assertTrue(str_contains($result, 'isFileAccepted(file, "image/*")'));
+        
+        // Should show rejection message
+        $this->assertTrue(str_contains($result, 'files are not accepted based on the file type restrictions'));
+    }
+
+    #[Test]
+    public function it_validates_clipboard_paste_files()
+    {
+        $result = $this->formField->fileModern('docs', ['accept' => '.pdf,.doc']);
+
+        // Should validate pasted files
+        $this->assertTrue(str_contains($result, 'isFileAccepted(file, ".pdf,.doc")'));
+    }
 }


### PR DESCRIPTION
Halo Mas @nafiesl ,
Merujuk ke issue https://github.com/buku-masjid/buku-masjid/issues/127 tentang "clipboard img paste & drag drop", sepertinya penambahannya perlu dilakukan sekalian dari sini.

Contoh implementasi nantinya akan seperti ini:

<img width="1061" height="927" alt="image" src="https://github.com/user-attachments/assets/c96c499c-8e52-498e-b04b-9b4e104e14ae" />


Contoh hasilnya:
<img width="487" height="893" alt="image" src="https://github.com/user-attachments/assets/7e7d6fb0-2c0f-48fc-99ff-c469f2afdc2d" />


Hanya saja, saya lihat buku-masjid menggunakan versi 2.* (BS4), sedangkan PR ini based on master (3.*, BS5). 
Perbedaan dari 2.* ke 3.* ada di laravelcollective/html dan konekt/html, dan juga mostly penambahan mb-3 dan fw-bold pada sebagian class, tapi saya coba versi 3.* (beserta fitur ini) ke buku-masjid sepertinya no issue Mas, apa ada concern tertentu ya?

Salam,
Arka.